### PR TITLE
Fix Dockerfile line continuation for ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
     espeak-ng \
-    libespeak-ng1 \\
+    libespeak-ng1 \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- fix line continuation in Dockerfile so ca-certificates is installed correctly

## Testing
- `pytest`
- `docker build .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68c822aa1d64832093a23fe9fae7e87e