### PR TITLE
Fix default Ollama model name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Environment configuration for Raspi Ollama WebUI
 OLLAMA_HOST=http://ollama:11434
-LLM_MODEL=llama3.2:1b-instruct
+LLM_MODEL=llama3.2:1b
 APP_HOST=0.0.0.0
 APP_PORT=8000
 WHISPER_MODEL=tiny

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ En superlätt WebUI för att köra Ollama på Raspberry Pi (ARM64). UI:t är på
 Första gången behöver du hämta en modell (t.ex. en liten som fungerar bra på Pi):
 
 ```bash
-docker exec -it ollama ollama pull llama3.2:1b-instruct
+docker exec -it ollama ollama pull llama3.2:1b
 ```
 
-> **Tips:** `llama3.2:1b-instruct` och `qwen2:0.5b-instruct` är små och brukar fungera på Pi, även med mindre RAM. Du kan byta modell i WebUI eller i `.env`.
+> **Tips:** `llama3.2:1b` och `qwen2:0.5b-instruct` är små och brukar fungera på Pi, även med mindre RAM. Du kan byta modell i WebUI eller i `.env`.
 
 ### Installera Docker & Compose på Raspberry Pi
 
@@ -61,7 +61,7 @@ python -m app.main
 ## Svenska stöd
 
 - WebUI är lokaliserad till svenska (texter i `i18n/sv.json`).
-- För bästa svenska resultat: använd en modern flerspråkig modell (t.ex. `llama3.2:1b-instruct`). Modellen kan väljas i UI:t.
+- För bästa svenska resultat: använd en modern flerspråkig modell (t.ex. `llama3.2:1b`). Modellen kan väljas i UI:t.
 - Vill du lägga till talsyntes/ASR? Se kommentarerna i `app/main.py` för hur du kan lägga till Whisper och TTS senare.
 
 ## Miljövariabler
@@ -70,14 +70,14 @@ Skapa en `.env` (eller använd `.env.example`):
 
 ```
 OLLAMA_HOST=http://ollama:11434
-LLM_MODEL=llama3.2:1b-instruct
+LLM_MODEL=llama3.2:1b
 APP_HOST=0.0.0.0
 APP_PORT=8000
 ```
 
 ## Endpoints (enkelt REST‑API)
 
-- `POST /api/chat` – Skicka `{ "messages": [{ "role":"user", "content":"Hej!" }], "model":"llama3.2:1b-instruct" }`
+- `POST /api/chat` – Skicka `{ "messages": [{ "role":"user", "content":"Hej!" }], "model":"llama3.2:1b" }`
 - `GET /api/models` – Lista lokalt installerade modeller via Ollama
 - `GET /` – WebUI (HTML/JS)
 
@@ -133,7 +133,7 @@ cd raspi-ollama-webui
 
 # 4) (Om Docker) starta allt
 docker compose up -d --build
-docker exec -it ollama ollama pull llama3.2:1b-instruct
+docker exec -it ollama ollama pull llama3.2:1b
 
 # 5) Öppna i webbläsare (på din dator): http://<pi-ip>:8000
 ```

--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
-DEFAULT_MODEL = os.getenv("LLM_MODEL", "llama3.2:1b-instruct")
+DEFAULT_MODEL = os.getenv("LLM_MODEL", "llama3.2:1b")
 APP_HOST = os.getenv("APP_HOST", "0.0.0.0")
 APP_PORT = int(os.getenv("APP_PORT", "8000"))
 

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -8,7 +8,7 @@ async function fetchModels() {
     if (models.length === 0) {
       // visa standard
       const opt = document.createElement('option');
-      opt.value = window.DEFAULT_MODEL || 'llama3.2:1b-instruct';
+      opt.value = window.DEFAULT_MODEL || 'llama3.2:1b';
       opt.textContent = opt.value + ' (ej installerad än)';
       sel.appendChild(opt);
     } else {
@@ -21,7 +21,7 @@ async function fetchModels() {
     }
   } catch (e) {
     const opt = document.createElement('option');
-    opt.value = window.DEFAULT_MODEL || 'llama3.2:1b-instruct';
+    opt.value = window.DEFAULT_MODEL || 'llama3.2:1b';
     opt.textContent = opt.value + ' (endpoint otillgänglig)';
     sel.appendChild(opt);
   }
@@ -39,7 +39,7 @@ function addMsg(role, text) {
 async function sendPrompt() {
   const ta = document.getElementById('prompt');
   const temperature = parseFloat(document.getElementById('temperature').value);
-  const model = document.getElementById('model').value || window.DEFAULT_MODEL || 'llama3.2:1b-instruct';
+  const model = document.getElementById('model').value || window.DEFAULT_MODEL || 'llama3.2:1b';
   const userText = ta.value.trim();
   if (!userText) return;
   addMsg('user', userText);

--- a/scripts/install_pi.sh
+++ b/scripts/install_pi.sh
@@ -27,6 +27,6 @@ if [ ! -f .env ]; then
 fi
 
 echo "Tips: Hämta en liten modell först (går snabbare och funkar på Pi):"
-echo "  ollama pull llama3.2:1b-instruct"
+echo "  ollama pull llama3.2:1b"
 echo
 echo "Starta appen med: python -m app.main"


### PR DESCRIPTION
## Summary
- update the default Ollama model to `llama3.2:1b`, which matches the tag shipped by Ollama
- refresh the web UI fallback, environment example, and documentation to point at the correct model
- align the Raspberry Pi install script tip with the new default model

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68c855138864832085cf27d3055ad739