### PR TITLE
Add network connection guidance and info endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ Första gången behöver du hämta en modell (t.ex. en liten som fungerar bra p�
 docker exec -it ollama ollama pull llama3.2:1b
 ```
 
+### Anslut från en annan dator i nätverket
+
+1. Se till att Raspberry Pi och datorn du vill ansluta ifrån är på samma lokala nätverk (t.ex. samma wifi/router).
+2. På din Pi: kör `hostname -I` eller `ip addr` för att se Pi:ns IP-adress.
+3. Öppna adressen i en webbläsare på din dator, t.ex. `http://<pi-ip>:8000`.
+4. Om du kör via Docker används port 8000 automatiskt. På bare-metal styrs porten av variabeln `APP_PORT` i `.env`.
+
+> **Tips:** WebUI:t visar en ruta "Anslut från en annan dator" med klickbara länkar när servern är igång. Dela en av dessa adresser med användare i samma nätverk.
+
 > **Tips:** `llama3.2:1b` och `qwen2:0.5b-instruct` är små och brukar fungera på Pi, även med mindre RAM. Du kan byta modell i WebUI eller i `.env`.
 
 ### Installera Docker & Compose på Raspberry Pi

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -4,6 +4,12 @@ header { padding: 12px 16px; background: #f4f4f5; border-bottom: 1px solid #e5e7
 header h1 { margin: 0; font-size: 1.1rem; }
 .row { display: flex; gap: 8px; align-items: center; }
 main { max-width: 920px; margin: 0 auto; padding: 16px; }
+#connect { margin-bottom: 16px; padding: 16px; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 12px; }
+#connect h2 { margin-top: 0; font-size: 1.05rem; }
+#connect ul { margin: 8px 0 0 18px; padding: 0; }
+#connect li { margin-bottom: 6px; }
+#connect a { color: #2563eb; text-decoration: none; }
+#connect a:hover { text-decoration: underline; }
 #history { display: flex; flex-direction: column; gap: 12px; margin-bottom: 12px; }
 .msg { padding: 12px 14px; border-radius: 12px; border: 1px solid #e5e7eb; }
 .msg.user { background: #eef2ff; }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -17,6 +17,11 @@
     </header>
 
     <main>
+      <section id="connect">
+        <h2>Anslut från en annan dator</h2>
+        <p id="connectText">Samlar adressinformation…</p>
+        <ul id="connectList"></ul>
+      </section>
       <section id="chat">
         <div id="history" aria-live="polite"></div>
         <div id="composer">
@@ -24,7 +29,6 @@
           <div class="row">
             <label for="temperature">Temperatur</label>
             <input type="range" min="0" max="2" step="0.1" id="temperature" value="0.7">
-            <button id="micBtn" title="Spela in (håll för att prata)">🎤</button>
             <button id="micBtn" title="Spela in (håll för att prata)">🎤</button>
             <button id="send">Skicka</button>
             <label class="row" style="gap:6px;"><input type="checkbox" id="ttsToggle" checked> Läs upp svar</label>


### PR DESCRIPTION
## Summary
- expose a new `/api/info` endpoint that reports configured host/port together with discovered network IP-adresser
- show the connection instructions and clickable links in the WebUI and polish the related styling
- document how to ansluta från en annan dator i README och fixa den dubbla mikrofonknappen

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68c856f9b2688320a8d1d0111196fd45