### PR TITLE
Add missing python-multipart dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ uvicorn==0.30.6
 httpx==0.27.2
 python-dotenv==1.0.1
 jinja2==3.1.4
+python-multipart==0.0.9
 
 faster-whisper==1.0.3
 pydub==0.25.1


### PR DESCRIPTION
## Summary
- add python-multipart to the application requirements so FastAPI's file upload endpoints can start successfully

## Testing
- pip install -r requirements.txt

------
https://chatgpt.com/codex/tasks/task_e_68c85ce805308320be92d8bf7cab16f4