### PR TITLE
Add RAG knowledge base and dynamic model selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,8 @@ OLLAMA_HOST=http://ollama:11434
 LLM_MODEL=llama3.2:1b
 APP_HOST=0.0.0.0
 APP_PORT=8000
+EMBED_MODEL=nomic-embed-text
+# RAG_STORE_PATH defaults to ~/.ollama_webui_rag.json if not set
+# RAG_STORE_PATH=/path/to/rag_store.json
 WHISPER_MODEL=tiny
 WHISPER_COMPUTE_TYPE=int8

--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ python -m app.main
 - För bästa svenska resultat: använd en modern flerspråkig modell (t.ex. `llama3.2:1b`). Modellen kan väljas i UI:t.
 - Vill du lägga till talsyntes/ASR? Se kommentarerna i `app/main.py` för hur du kan lägga till Whisper och TTS senare.
 
+## Kunskapsbas (RAG)
+
+- I WebUI finns en sektion "Kunskapsbas (RAG)" där du kan klistra in egna texter/anteckningar.
+- Texten delas upp i utdrag och indexeras med Ollamas embeddings-API (`/api/embeddings`).
+- Aktivera kryssrutan **Använd kunskapsbas (RAG)** i chat-kompositören för att injicera utdragen i prompten.
+- Du kan välja hur många utdrag som ska hämtas (1–10) och se vilka utdrag som användes i svaret.
+- Embeddings lagras som standard i `~/.ollama_webui_rag.json`. Ändra via `RAG_STORE_PATH` vid behov.
+- Säkerställ att du har en embeddings-modell installerad i Ollama (t.ex. `ollama pull nomic-embed-text`).
+
 ## Miljövariabler
 
 Skapa en `.env` (eller använd `.env.example`):
@@ -82,6 +91,9 @@ OLLAMA_HOST=http://ollama:11434
 LLM_MODEL=llama3.2:1b
 APP_HOST=0.0.0.0
 APP_PORT=8000
+EMBED_MODEL=nomic-embed-text
+# valfritt, ändra var kunskapsbasen sparas
+# RAG_STORE_PATH=/path/to/rag_store.json
 ```
 
 ## Endpoints (enkelt REST‑API)

--- a/app/rag_store.py
+++ b/app/rag_store.py
@@ -1,0 +1,268 @@
+import asyncio
+import json
+import os
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import httpx
+import numpy as np
+
+
+@dataclass
+class RAGResult:
+    doc_id: str
+    chunk_index: int
+    text: str
+    score: float
+
+
+class RAGStore:
+    """Very small in-process vector store backed by Ollama embeddings."""
+
+    def __init__(self, ollama_host: str, embed_model: str, storage_path: str) -> None:
+        self.ollama_host = ollama_host.rstrip("/")
+        self.embed_model = embed_model
+        self.storage_path = storage_path
+        self.documents: List[Dict[str, Any]] = []
+        self._chunk_refs: List[Dict[str, Any]] = []
+        self._chunk_matrix: np.ndarray = np.empty((0, 0), dtype=np.float32)
+        self._lock = asyncio.Lock()
+        self._load()
+        self._rebuild_index()
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        if not self.storage_path:
+            return
+        try:
+            with open(self.storage_path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+                docs = data.get("documents") if isinstance(data, dict) else None
+                if isinstance(docs, list):
+                    self.documents = docs
+        except FileNotFoundError:
+            self.documents = []
+        except json.JSONDecodeError:
+            # Corrupt file – ignore but keep empty store
+            self.documents = []
+        except OSError:
+            self.documents = []
+
+    def _save(self) -> None:
+        if not self.storage_path:
+            return
+        directory = os.path.dirname(self.storage_path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+        tmp_path = f"{self.storage_path}.tmp"
+        payload = {"documents": self.documents, "updated_at": datetime.utcnow().isoformat()}
+        with open(tmp_path, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, ensure_ascii=False, indent=2)
+        os.replace(tmp_path, self.storage_path)
+
+    def _rebuild_index(self) -> None:
+        refs: List[Dict[str, Any]] = []
+        vectors: List[np.ndarray] = []
+        for doc in self.documents:
+            doc_id = doc.get("id")
+            chunks = doc.get("chunks") or []
+            for chunk in chunks:
+                vec = chunk.get("embedding")
+                text = chunk.get("text", "")
+                if not isinstance(vec, list) or not vec:
+                    continue
+                try:
+                    arr = np.asarray(vec, dtype=np.float32)
+                except (ValueError, TypeError):
+                    continue
+                norm = np.linalg.norm(arr)
+                if norm == 0:
+                    continue
+                vectors.append(arr / norm)
+                refs.append({
+                    "doc_id": doc_id,
+                    "chunk_index": int(chunk.get("index", 0)),
+                    "text": text,
+                })
+        if vectors:
+            self._chunk_matrix = np.vstack(vectors)
+        else:
+            self._chunk_matrix = np.empty((0, 0), dtype=np.float32)
+        self._chunk_refs = refs
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    async def stats(self) -> Dict[str, int]:
+        async with self._lock:
+            chunk_count = sum(len(doc.get("chunks") or []) for doc in self.documents)
+            return {
+                "document_count": len(self.documents),
+                "chunk_count": chunk_count,
+            }
+
+    async def list_documents(self) -> List[Dict[str, Any]]:
+        async with self._lock:
+            items: List[Dict[str, Any]] = []
+            for doc in self.documents:
+                raw_text = (doc.get("text") or "").strip().replace("\r\n", " ").replace("\n", " ")
+                preview = raw_text[:160] + ("…" if len(raw_text) > 160 else "")
+                items.append({
+                    "id": doc.get("id"),
+                    "preview": preview,
+                    "chunks": len(doc.get("chunks") or []),
+                    "created_at": doc.get("created_at"),
+                })
+            return items
+
+    async def clear(self) -> None:
+        async with self._lock:
+            self.documents = []
+            self._rebuild_index()
+            self._save()
+
+    async def delete_document(self, doc_id: str) -> bool:
+        async with self._lock:
+            original_len = len(self.documents)
+            self.documents = [doc for doc in self.documents if doc.get("id") != doc_id]
+            removed = len(self.documents) != original_len
+            if removed:
+                self._rebuild_index()
+                self._save()
+            return removed
+
+    async def add_document(self, text: str) -> Dict[str, Any]:
+        cleaned = (text or "").strip()
+        if not cleaned:
+            raise ValueError("Skriv in text att lägga till i kunskapsbasen.")
+        chunks = self._chunk_text(cleaned)
+        if not chunks:
+            raise ValueError("Kunde inte dela upp texten i utdrag.")
+
+        embeddings: List[List[float]] = []
+        for chunk in chunks:
+            embedding = await self._embed_text(chunk)
+            embeddings.append([float(x) for x in embedding])
+
+        doc_id = str(uuid.uuid4())
+        created_at = datetime.utcnow().isoformat()
+        stored_chunks = []
+        for idx, (chunk_text, embedding) in enumerate(zip(chunks, embeddings)):
+            stored_chunks.append({
+                "index": idx,
+                "text": chunk_text,
+                "embedding": embedding,
+            })
+        new_doc = {
+            "id": doc_id,
+            "text": cleaned,
+            "chunks": stored_chunks,
+            "created_at": created_at,
+        }
+        async with self._lock:
+            self.documents.append(new_doc)
+            self._rebuild_index()
+            self._save()
+        preview = cleaned[:160] + ("…" if len(cleaned) > 160 else "")
+        return {
+            "id": doc_id,
+            "preview": preview,
+            "chunks": len(stored_chunks),
+            "created_at": created_at,
+        }
+
+    async def search(self, query: str, top_k: int = 3) -> List[RAGResult]:
+        question = (query or "").strip()
+        if not question:
+            return []
+        top_k = max(1, min(int(top_k), 10))
+        async with self._lock:
+            if not self._chunk_refs or self._chunk_matrix.size == 0:
+                return []
+            matrix = self._chunk_matrix.copy()
+            refs = list(self._chunk_refs)
+        embedding = await self._embed_text(question)
+        query_vec = np.asarray(embedding, dtype=np.float32)
+        q_norm = np.linalg.norm(query_vec)
+        if q_norm == 0:
+            return []
+        query_vec /= q_norm
+        scores = matrix @ query_vec
+        if scores.ndim == 0:
+            scores = np.asarray([float(scores)])
+        ranked_indices = np.argsort(scores)[::-1][:top_k]
+        results: List[RAGResult] = []
+        for idx in ranked_indices:
+            ref = refs[int(idx)]
+            results.append(RAGResult(
+                doc_id=str(ref.get("doc_id")),
+                chunk_index=int(ref.get("chunk_index", 0)),
+                text=str(ref.get("text", "")),
+                score=float(scores[int(idx)]),
+            ))
+        return results
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _chunk_text(self, text: str, max_chars: int = 600) -> List[str]:
+        norm = text.replace("\r\n", "\n")
+        paragraphs = [p.strip() for p in norm.split("\n\n") if p.strip()]
+        chunks: List[str] = []
+        for para in paragraphs:
+            part = para
+            while len(part) > max_chars:
+                split_at = part.rfind(" ", 0, max_chars)
+                if split_at <= 0:
+                    split_at = max_chars
+                chunk = part[:split_at].strip()
+                if chunk:
+                    chunks.append(chunk)
+                part = part[split_at:].strip()
+            if part:
+                chunks.append(part)
+        if not chunks and norm:
+            chunks.append(norm[:max_chars])
+        return chunks
+
+    async def _embed_text(self, text: str) -> List[float]:
+        url = f"{self.ollama_host}/api/embeddings"
+        payload = {
+            "model": self.embed_model,
+            "prompt": text,
+        }
+        try:
+            async with httpx.AsyncClient(timeout=120) as client:
+                response = await client.post(url, json=payload)
+                response.raise_for_status()
+        except httpx.HTTPStatusError as exc:  # type: ignore[no-untyped-def]
+            detail = exc.response.text
+            raise RuntimeError(
+                f"Kunde inte generera embedding ({exc.response.status_code}): {detail}"
+            ) from exc
+        except httpx.HTTPError as exc:  # type: ignore[no-untyped-def]
+            raise RuntimeError(f"Kunde inte nå Ollama för embedding: {exc}") from exc
+
+        try:
+            data = response.json()
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("Ollama svarade med ogiltig JSON för embeddings.") from exc
+
+        embedding: Optional[List[float]] = None
+        raw_embedding = data.get("embedding")
+        if isinstance(raw_embedding, list):
+            embedding = raw_embedding
+        else:
+            data_list = data.get("data")
+            if isinstance(data_list, list) and data_list:
+                first = data_list[0] if isinstance(data_list[0], dict) else None
+                maybe_embedding = first.get("embedding") if isinstance(first, dict) else None
+                if isinstance(maybe_embedding, list):
+                    embedding = maybe_embedding
+        if embedding is None:
+            raise RuntimeError("Embedding saknas i svaret från Ollama. Kontrollera att modellen stödjer embeddings.")
+        return embedding

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -3,6 +3,7 @@ body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-seri
 header { padding: 12px 16px; background: #f4f4f5; border-bottom: 1px solid #e5e7eb; display: flex; gap: 12px; align-items: center; justify-content: space-between; flex-wrap: wrap; }
 header h1 { margin: 0; font-size: 1.1rem; }
 .row { display: flex; gap: 8px; align-items: center; }
+.row.wrap { flex-wrap: wrap; align-items: center; }
 main { max-width: 920px; margin: 0 auto; padding: 16px; }
 #connect { margin-bottom: 16px; padding: 16px; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 12px; }
 #connect h2 { margin-top: 0; font-size: 1.05rem; }
@@ -24,3 +25,28 @@ code { background: #f3f4f6; padding: 2px 6px; border-radius: 6px; }
 
 
 #micBtn.recording { background: #fee2e2; border-color: #ef4444; }
+
+#rag { margin-bottom: 16px; padding: 16px; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 12px; }
+#rag textarea { width: 100%; min-height: 120px; resize: vertical; font-size: 0.95rem; padding: 10px; border-radius: 8px; border: 1px solid #d1d5db; }
+.rag-controls { margin-top: 10px; gap: 12px; }
+.rag-controls button { padding: 8px 12px; }
+.rag-meta { font-size: 0.9rem; color: #4b5563; }
+.rag-status { margin: 8px 0 0; color: #4b5563; font-size: 0.9rem; min-height: 1em; }
+.rag-status.error { color: #dc2626; }
+.rag-status.success { color: #15803d; }
+.rag-list { list-style: none; margin: 12px 0 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
+.rag-list li { background: #ffffff; border: 1px solid #e5e7eb; border-radius: 10px; padding: 10px 12px; display: flex; flex-direction: column; gap: 6px; }
+.rag-list li .preview { white-space: pre-wrap; font-size: 0.95rem; color: #111827; }
+.rag-list li .meta { font-size: 0.85rem; color: #6b7280; display: flex; gap: 12px; flex-wrap: wrap; }
+.rag-list li button { align-self: flex-start; font-size: 0.85rem; padding: 6px 10px; }
+
+.fine-controls { margin-top: 8px; gap: 16px; }
+.fine-controls .row { gap: 6px; }
+.fine-controls input[type="number"] { width: 70px; padding: 6px; }
+.rag-toggle input { margin-right: 6px; }
+
+.rag-results { margin: 12px 0; padding: 12px; border: 1px dashed #cbd5f5; border-radius: 10px; background: #f9fafb; }
+.rag-results[hidden] { display: none !important; }
+.rag-results h3 { margin: 0 0 8px; font-size: 1rem; }
+.rag-results ol { margin: 0; padding-left: 18px; display: flex; flex-direction: column; gap: 6px; }
+.rag-results li { white-space: pre-wrap; font-size: 0.95rem; color: #1f2937; }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -22,17 +22,37 @@
         <p id="connectText">Samlar adressinformation…</p>
         <ul id="connectList"></ul>
       </section>
+      <section id="rag">
+        <h2>Kunskapsbas (RAG)</h2>
+        <p>Lägg till egen fakta som modellen kan använda när RAG är aktiverat.</p>
+        <textarea id="ragInput" rows="4" placeholder="Klistra in anteckningar eller dokumentutdrag…"></textarea>
+        <div class="row wrap rag-controls">
+          <button id="addRag">Lägg till text</button>
+          <button id="clearRag">Töm kunskapsbasen</button>
+          <span class="rag-meta">Embeddings-modell: <code id="ragModelName">–</code></span>
+        </div>
+        <p id="ragStatus" class="rag-status"></p>
+        <ul id="ragList" class="rag-list"></ul>
+      </section>
       <section id="chat">
         <div id="history" aria-live="polite"></div>
+        <div id="ragResults" class="rag-results" hidden>
+          <h3>Kontext från kunskapsbasen</h3>
+          <ol></ol>
+        </div>
         <div id="composer">
           <textarea id="prompt" rows="3" placeholder="Skriv på svenska…"></textarea>
-          <div class="row">
+          <div class="row wrap">
             <label for="temperature">Temperatur</label>
             <input type="range" min="0" max="2" step="0.1" id="temperature" value="0.7">
             <button id="micBtn" title="Spela in (håll för att prata)">🎤</button>
             <button id="send">Skicka</button>
             <label class="row" style="gap:6px;"><input type="checkbox" id="ttsToggle" checked> Läs upp svar</label>
             <button id="dlTts" title="Ladda ner ljud av senaste svar">🔊 Ladda ner ljud</button>
+          </div>
+          <div class="row wrap fine-controls">
+            <label class="row rag-toggle"><input type="checkbox" id="ragToggle"> Använd kunskapsbas (RAG)</label>
+            <label class="row rag-topk" for="ragTopK">Antal utdrag <input type="number" id="ragTopK" min="1" max="10" value="3"></label>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- add a lightweight Ollama-backed RAG store with REST endpoints and chat enrichment
- expose RAG management, context previews, and a persistent model selector in the WebUI
- document the new embedding configuration and knowledge base workflow

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68c91145e7d48320874fbc14af9c8309