### PR TITLE
Add dedicated RAG page with URL and PDF ingestion

### DIFF
--- a/app/static/rag.js
+++ b/app/static/rag.js
@@ -1,0 +1,290 @@
+function setEndpointDisplay() {
+  const endpointEl = document.getElementById('endpoint');
+  if (endpointEl) {
+    endpointEl.textContent = (window.location.origin + '/api').replace('/api', '/');
+  }
+}
+
+function setRagStatus(message, type = 'info') {
+  const statusEl = document.getElementById('ragStatus');
+  if (!statusEl) return;
+  statusEl.textContent = message || '';
+  statusEl.classList.remove('error', 'success');
+  if (type === 'error') statusEl.classList.add('error');
+  if (type === 'success') statusEl.classList.add('success');
+}
+
+function describeMetadata(meta) {
+  if (!meta || typeof meta !== 'object') return '';
+  const parts = [];
+  const limit = window.RAG_MAX_CHARS || 40000;
+  switch (meta.type) {
+    case 'url': {
+      if (meta.title) {
+        parts.push(`Webbsida: ${meta.title}`);
+      } else {
+        parts.push('Webbsida');
+      }
+      if (meta.url) {
+        parts.push(meta.url);
+      }
+      break;
+    }
+    case 'pdf': {
+      const name = meta.filename || 'PDF';
+      parts.push(`PDF: ${name}`);
+      if (meta.pages_used && meta.total_pages) {
+        parts.push(`Sidor ${meta.pages_used}/${meta.total_pages}`);
+      } else if (meta.total_pages) {
+        parts.push(`${meta.total_pages} sidor`);
+      }
+      break;
+    }
+    default:
+      parts.push('Manuell text');
+      break;
+  }
+  if (meta.original_characters) {
+    parts.push(`≈ ${meta.original_characters} tecken före delning`);
+  }
+  if (meta.truncated) {
+    parts.push(`Trunkerad till ${limit} tecken`);
+  }
+  return parts.join(' • ');
+}
+
+function updateSummary(count, chunkCount) {
+  const summaryEl = document.getElementById('ragSummaryText');
+  if (!summaryEl) return;
+  if (!count) {
+    summaryEl.textContent = 'Ingen text har lagts till ännu.';
+    return;
+  }
+  const chunkLabel = chunkCount === 1 ? 'utdrag' : 'utdrag';
+  summaryEl.textContent = `Texter: ${count} • ${chunkCount} ${chunkLabel}.`;
+}
+
+function renderRagDocs(docs, stats) {
+  const listEl = document.getElementById('ragList');
+  const clearBtn = document.getElementById('clearRag');
+  const safeDocs = Array.isArray(docs) ? docs : [];
+  const chunkCountRaw = (stats && typeof stats.chunk_count !== 'undefined') ? stats.chunk_count : 0;
+  const chunkCount = Number(chunkCountRaw) || 0;
+
+  if (listEl) {
+    listEl.innerHTML = '';
+    safeDocs.forEach((doc) => {
+      const li = document.createElement('li');
+
+      const preview = document.createElement('div');
+      preview.className = 'preview';
+      preview.textContent = doc.preview || '[Tom text]';
+      li.appendChild(preview);
+
+      const meta = document.createElement('div');
+      meta.className = 'meta';
+      const chunkInfo = document.createElement('span');
+      const chunkLabel = (doc.chunks === 1) ? 'utdrag' : 'utdrag';
+      chunkInfo.textContent = `${doc.chunks || 0} ${chunkLabel}`;
+      meta.appendChild(chunkInfo);
+      if (doc.created_at) {
+        const created = new Date(doc.created_at);
+        if (!Number.isNaN(created.valueOf())) {
+          const createdSpan = document.createElement('span');
+          createdSpan.textContent = created.toLocaleString('sv-SE');
+          meta.appendChild(createdSpan);
+        }
+      }
+      li.appendChild(meta);
+
+      const metaInfo = describeMetadata(doc.metadata);
+      if (metaInfo) {
+        const source = document.createElement('div');
+        source.className = 'meta source';
+        source.textContent = metaInfo;
+        li.appendChild(source);
+      }
+
+      const removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.textContent = 'Ta bort';
+      removeBtn.addEventListener('click', () => deleteRagDoc(doc.id));
+      li.appendChild(removeBtn);
+
+      listEl.appendChild(li);
+    });
+  }
+
+  if (clearBtn) {
+    clearBtn.disabled = safeDocs.length === 0;
+  }
+
+  updateSummary(safeDocs.length, chunkCount);
+  return { count: safeDocs.length, chunkCount };
+}
+
+async function fetchRagDocs(statusOverride) {
+  if (!statusOverride) {
+    setRagStatus('Hämtar kunskapsbas…');
+  }
+  try {
+    const res = await fetch('/api/rag/docs');
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    const data = await res.json();
+    const summary = renderRagDocs(data.documents, data.stats);
+    if (data && data.embedding_model) {
+      const modelEl = document.getElementById('ragModelName');
+      if (modelEl) {
+        modelEl.textContent = data.embedding_model;
+      }
+    }
+    if (statusOverride && statusOverride.text) {
+      setRagStatus(statusOverride.text, statusOverride.type || 'info');
+    } else if (summary.count === 0) {
+      setRagStatus('Ingen text har lagts till ännu.');
+    } else {
+      const chunkLabel = summary.chunkCount === 1 ? 'utdrag' : 'utdrag';
+      setRagStatus(`Texter: ${summary.count} • ${summary.chunkCount} ${chunkLabel}.`);
+    }
+  } catch (e) {
+    setRagStatus('Kunde inte hämta kunskapsbasen: ' + e.message, 'error');
+    const listEl = document.getElementById('ragList');
+    if (listEl) listEl.innerHTML = '';
+    updateSummary(0, 0);
+    const clearBtn = document.getElementById('clearRag');
+    if (clearBtn) clearBtn.disabled = true;
+  }
+}
+
+async function addTextDoc() {
+  const textarea = document.getElementById('ragTextInput');
+  const btn = document.getElementById('addTextBtn');
+  if (!textarea || !btn) return;
+  const text = textarea.value.trim();
+  if (!text) {
+    setRagStatus('Skriv eller klistra in text först.', 'error');
+    return;
+  }
+  setRagStatus('Lägger till text…');
+  btn.disabled = true;
+  try {
+    const res = await fetch('/api/rag/docs', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text })
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      throw new Error(data.detail || ('HTTP ' + res.status));
+    }
+    textarea.value = '';
+    await fetchRagDocs({ text: 'Texten lades till i kunskapsbasen.', type: 'success' });
+  } catch (e) {
+    setRagStatus('Kunde inte lägga till text: ' + e.message, 'error');
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+async function addUrlDoc() {
+  const input = document.getElementById('ragUrlInput');
+  const btn = document.getElementById('addUrlBtn');
+  if (!input || !btn) return;
+  const url = input.value.trim();
+  if (!url) {
+    setRagStatus('Ange en URL först.', 'error');
+    return;
+  }
+  setRagStatus('Hämtar webbsidan…');
+  btn.disabled = true;
+  try {
+    const res = await fetch('/api/rag/docs/url', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url })
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      throw new Error(data.detail || ('HTTP ' + res.status));
+    }
+    input.value = '';
+    await fetchRagDocs({ text: 'Webbsidan lades till i kunskapsbasen.', type: 'success' });
+  } catch (e) {
+    setRagStatus('Kunde inte lägga till webbsidan: ' + e.message, 'error');
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+async function uploadPdf(event) {
+  event.preventDefault();
+  const input = document.getElementById('ragPdfInput');
+  const form = document.getElementById('ragPdfForm');
+  if (!input || !form) return;
+  const file = input.files && input.files[0];
+  if (!file) {
+    setRagStatus('Välj en PDF-fil först.', 'error');
+    return;
+  }
+  setRagStatus('Laddar upp PDF…');
+  const submitBtn = form.querySelector('button[type="submit"]');
+  if (submitBtn) submitBtn.disabled = true;
+  try {
+    const formData = new FormData();
+    formData.append('file', file);
+    const res = await fetch('/api/rag/docs/pdf', { method: 'POST', body: formData });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      throw new Error(data.detail || ('HTTP ' + res.status));
+    }
+    input.value = '';
+    await fetchRagDocs({ text: 'PDF-filen lades till i kunskapsbasen.', type: 'success' });
+  } catch (e) {
+    setRagStatus('Kunde inte lägga till PDF: ' + e.message, 'error');
+  } finally {
+    if (submitBtn) submitBtn.disabled = false;
+  }
+}
+
+async function deleteRagDoc(id) {
+  if (!id) return;
+  try {
+    const res = await fetch(`/api/rag/docs/${encodeURIComponent(id)}`, { method: 'DELETE' });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      throw new Error(data.detail || ('HTTP ' + res.status));
+    }
+    await fetchRagDocs({ text: 'Texten togs bort.', type: 'success' });
+  } catch (e) {
+    setRagStatus('Kunde inte ta bort text: ' + e.message, 'error');
+  }
+}
+
+async function clearRagDocs() {
+  if (!window.confirm('Är du säker på att du vill tömma kunskapsbasen?')) {
+    return;
+  }
+  try {
+    const res = await fetch('/api/rag/docs', { method: 'DELETE' });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      throw new Error(data.detail || ('HTTP ' + res.status));
+    }
+    await fetchRagDocs({ text: 'Kunskapsbasen tömdes.', type: 'success' });
+  } catch (e) {
+    setRagStatus('Kunde inte rensa kunskapsbasen: ' + e.message, 'error');
+  }
+}
+
+setEndpointDisplay();
+setRagStatus('');
+fetchRagDocs();
+
+const addTextButton = document.getElementById('addTextBtn');
+if (addTextButton) addTextButton.addEventListener('click', addTextDoc);
+const addUrlButton = document.getElementById('addUrlBtn');
+if (addUrlButton) addUrlButton.addEventListener('click', addUrlDoc);
+const pdfForm = document.getElementById('ragPdfForm');
+if (pdfForm) pdfForm.addEventListener('submit', uploadPdf);
+const clearBtn = document.getElementById('clearRag');
+if (clearBtn) clearBtn.addEventListener('click', clearRagDocs);

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -2,9 +2,16 @@
 body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; color: #111; }
 header { padding: 12px 16px; background: #f4f4f5; border-bottom: 1px solid #e5e7eb; display: flex; gap: 12px; align-items: center; justify-content: space-between; flex-wrap: wrap; }
 header h1 { margin: 0; font-size: 1.1rem; }
+header p { margin: 0; color: #4b5563; font-size: 0.95rem; }
+.header-copy { display: flex; flex-direction: column; gap: 4px; }
+.back-link { color: #2563eb; text-decoration: none; font-weight: 600; }
+.back-link:hover { text-decoration: underline; }
 .row { display: flex; gap: 8px; align-items: center; }
 .row.wrap { flex-wrap: wrap; align-items: center; }
 main { max-width: 920px; margin: 0 auto; padding: 16px; }
+#ragSummary { margin-bottom: 16px; padding: 16px; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 12px; }
+#ragSummary a { color: #2563eb; text-decoration: none; }
+#ragSummary a:hover { text-decoration: underline; }
 #connect { margin-bottom: 16px; padding: 16px; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 12px; }
 #connect h2 { margin-top: 0; font-size: 1.05rem; }
 #connect ul { margin: 8px 0 0 18px; padding: 0; }
@@ -26,19 +33,25 @@ code { background: #f3f4f6; padding: 2px 6px; border-radius: 6px; }
 
 #micBtn.recording { background: #fee2e2; border-color: #ef4444; }
 
-#rag { margin-bottom: 16px; padding: 16px; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 12px; }
-#rag textarea { width: 100%; min-height: 120px; resize: vertical; font-size: 0.95rem; padding: 10px; border-radius: 8px; border: 1px solid #d1d5db; }
+.rag-page { display: flex; flex-direction: column; gap: 16px; }
+.rag-section { padding: 16px; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 12px; }
+.rag-section textarea { width: 100%; min-height: 140px; resize: vertical; font-size: 0.95rem; padding: 10px; border-radius: 8px; border: 1px solid #d1d5db; }
 .rag-controls { margin-top: 10px; gap: 12px; }
 .rag-controls button { padding: 8px 12px; }
 .rag-meta { font-size: 0.9rem; color: #4b5563; }
 .rag-status { margin: 8px 0 0; color: #4b5563; font-size: 0.9rem; min-height: 1em; }
 .rag-status.error { color: #dc2626; }
 .rag-status.success { color: #15803d; }
+.field-help { margin: 0; font-size: 0.9rem; color: #4b5563; }
 .rag-list { list-style: none; margin: 12px 0 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
 .rag-list li { background: #ffffff; border: 1px solid #e5e7eb; border-radius: 10px; padding: 10px 12px; display: flex; flex-direction: column; gap: 6px; }
 .rag-list li .preview { white-space: pre-wrap; font-size: 0.95rem; color: #111827; }
 .rag-list li .meta { font-size: 0.85rem; color: #6b7280; display: flex; gap: 12px; flex-wrap: wrap; }
+.rag-list li .meta.source { color: #4b5563; }
 .rag-list li button { align-self: flex-start; font-size: 0.85rem; padding: 6px 10px; }
+.rag-url-form input[type="url"] { flex: 1; min-width: 240px; padding: 8px; border-radius: 8px; border: 1px solid #d1d5db; }
+.rag-pdf-form input[type="file"] { flex: 1; min-width: 200px; }
+.section-header { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
 
 .fine-controls { margin-top: 8px; gap: 16px; }
 .fine-controls .row { gap: 6px; }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -22,17 +22,10 @@
         <p id="connectText">Samlar adressinformation…</p>
         <ul id="connectList"></ul>
       </section>
-      <section id="rag">
+      <section id="ragSummary">
         <h2>Kunskapsbas (RAG)</h2>
-        <p>Lägg till egen fakta som modellen kan använda när RAG är aktiverat.</p>
-        <textarea id="ragInput" rows="4" placeholder="Klistra in anteckningar eller dokumentutdrag…"></textarea>
-        <div class="row wrap rag-controls">
-          <button id="addRag">Lägg till text</button>
-          <button id="clearRag">Töm kunskapsbasen</button>
-          <span class="rag-meta">Embeddings-modell: <code id="ragModelName">–</code></span>
-        </div>
-        <p id="ragStatus" class="rag-status"></p>
-        <ul id="ragList" class="rag-list"></ul>
+        <p>Hantera dokumenten på den <a href="/rag">dedikerade RAG-sidan</a>. När RAG är aktiverat i chatten används dokumenten som extra kontext.</p>
+        <p id="ragSummaryText" class="rag-status">Hämtar statistik…</p>
       </section>
       <section id="chat">
         <div id="history" aria-live="polite"></div>

--- a/app/templates/rag.html
+++ b/app/templates/rag.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="sv">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Kunskapsbas (RAG) – Raspi Ollama WebUI</title>
+    <link rel="stylesheet" href="/static/style.css" />
+  </head>
+  <body>
+    <header class="page-header">
+      <div class="header-copy">
+        <h1>Kunskapsbas (RAG)</h1>
+        <p>Hantera dokument som används som kontext när RAG är aktiverat i chatten.</p>
+      </div>
+      <a class="back-link" href="/">← Tillbaka till chatten</a>
+    </header>
+
+    <main class="rag-page">
+      <section class="rag-section" id="ragOverview">
+        <h2>Översikt</h2>
+        <p>Embeddings-modell: <code id="ragModelName">{{ embedding_model }}</code></p>
+        <p id="ragSummaryText">Hämtar statistik…</p>
+      </section>
+
+      <section class="rag-section">
+        <h2>Lägg till text manuellt</h2>
+        <textarea id="ragTextInput" rows="5" placeholder="Klistra in eller skriv text…"></textarea>
+        <div class="row wrap rag-controls">
+          <button id="addTextBtn" type="button">Lägg till text</button>
+        </div>
+      </section>
+
+      <section class="rag-section">
+        <h2>Importera webbsida</h2>
+        <div class="row wrap rag-url-form">
+          <input type="url" id="ragUrlInput" placeholder="https://exempel.se/artikel" />
+          <button id="addUrlBtn" type="button">Hämta och lägg till</button>
+        </div>
+        <p class="field-help">Sidan hämtas server-side och bara texten sparas. Maximalt {{ MAX_IMPORTED_CHARS }} tecken används.</p>
+      </section>
+
+      <section class="rag-section">
+        <h2>Ladda upp PDF</h2>
+        <form id="ragPdfForm" class="row wrap rag-pdf-form">
+          <input type="file" id="ragPdfInput" accept="application/pdf" />
+          <button type="submit">Lägg till PDF</button>
+        </form>
+        <p class="field-help">Stöd för PDF-filer upp till 8&nbsp;MB. De första 40 sidorna används.</p>
+      </section>
+
+      <section class="rag-section">
+        <div class="section-header">
+          <h2>Dokument i kunskapsbasen</h2>
+          <button id="clearRag" type="button">Töm hela kunskapsbasen</button>
+        </div>
+        <p id="ragStatus" class="rag-status"></p>
+        <ul id="ragList" class="rag-list"></ul>
+      </section>
+    </main>
+
+    <footer>
+      <small>Ollama endpoint: <code id="endpoint"></code></small>
+    </footer>
+
+    <script>
+      window.RAG_MAX_CHARS = {{ MAX_IMPORTED_CHARS }};
+    </script>
+    <script src="/static/rag.js"></script>
+  </body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ httpx==0.27.2
 python-dotenv==1.0.1
 jinja2==3.1.4
 python-multipart==0.0.9
+beautifulsoup4==4.12.3
+pypdf==5.1.0
 
 faster-whisper==1.0.3
 pydub==0.25.1


### PR DESCRIPTION
## Summary
- add a dedicated RAG-hanterare med möjlighet att lägga till text, webbadresser och PDF-filer direkt från frontend
- utöka backend med normalisering, HTML-/PDF-extraktion och metadata för RAG-dokument
- uppdatera startsidan och stilar för att länka till den nya sidan och visa en sammanfattning av kunskapsbasen

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68c91ac235908320b4416f7db9359e48