### PR TITLE
Add embedding availability guidance to RAG UI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -210,10 +210,12 @@ async def list_models():
 async def list_rag_documents():
     docs = await rag_store.list_documents()
     stats = await rag_store.stats()
+    embedding_status = await rag_store.embedding_status()
     return {
         "documents": docs,
         "stats": stats,
         "embedding_model": EMBED_MODEL,
+        "embedding_status": embedding_status,
     }
 
 


### PR DESCRIPTION
## Summary
- add a backend embedding model status check and expose it from the RAG documents endpoint
- disable RAG inputs and surface installation guidance in the UI when the embedding model is missing

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68c9296f4f1883209c6865472aeacd16