### PR TITLE
Add selectable TTS engines for Whisper and MBROLA

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ Projektet har inbyggt stöd för **Whisper (ASR)** via `faster-whisper`. I webUI
 ### Bare-metal
 Installationsscriptet installerar `ffmpeg`. Se `.env.example` för konfig.
 
+## Text till tal (TTS)
+
+- WebUI:t låter dig välja TTS-lösning direkt i chatten (dropdown bredvid "Läs upp svar").
+- **Whisper** syftar här på eSpeak NG:s viskande röstvariant.
+- **eSpeak NG + MBROLA** använder MBROLA-röster (t.ex. `mb-sv1`) om de finns installerade.
+- Saknas MBROLA-röster visas alternativet som otillgängligt tills du installerat dem.
+
 ## GitHub-repo
 
 1. Skapa ett nytt repo på GitHub (t.ex. `raspi-ollama-webui`).

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -22,6 +22,9 @@ main { max-width: 920px; margin: 0 auto; padding: 16px; }
 .msg { padding: 12px 14px; border-radius: 12px; border: 1px solid #e5e7eb; }
 .msg.user { background: #eef2ff; }
 .msg.assistant { background: #f1f5f9; }
+.msg.notice { background: #fff7ed; border-color: #fb923c; color: #9a3412; }
+#composer .tts-select { gap: 6px; }
+#composer .tts-select select { min-width: 180px; }
 #composer { position: sticky; bottom: 0; background: white; border-top: 1px solid #e5e7eb; padding: 12px 0; }
 #prompt { width: 100%; font-size: 1rem; padding: 10px; border-radius: 8px; border: 1px solid #e5e7eb; }
 button { padding: 8px 12px; border-radius: 10px; border: 1px solid #d1d5db; background: #ffffff; cursor: pointer; }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -41,6 +41,12 @@
             <button id="micBtn" title="Spela in (håll för att prata)">🎤</button>
             <button id="send">Skicka</button>
             <label class="row" style="gap:6px;"><input type="checkbox" id="ttsToggle" checked> Läs upp svar</label>
+            <label class="row tts-select" for="ttsEngine" title="Välj talsyntes">
+              Röst
+              <select id="ttsEngine">
+                <option value="browser">Webbläsare (inbyggd)</option>
+              </select>
+            </label>
             <button id="dlTts" title="Ladda ner ljud av senaste svar">🔊 Ladda ner ljud</button>
           </div>
           <div class="row wrap fine-controls">


### PR DESCRIPTION
## Summary
- expose available TTS engines/voices and allow choosing Whisper or eSpeak NG + MBROLA on the server
- rework the WebUI to select and play/download speech with the chosen engine and show friendly notices
- document the new TTS choices and add styling for the selector and info messages

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68c9452686508320af92af5fa913375a