### PR TITLE
Handle missing eSpeak dependency for TTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Installationsscriptet installerar `ffmpeg`. Se `.env.example` för konfig.
 - **Whisper** syftar här på eSpeak NG:s viskande röstvariant.
 - **eSpeak NG + MBROLA** använder MBROLA-röster (t.ex. `mb-sv1`) om de finns installerade.
 - Saknas MBROLA-röster visas alternativet som otillgängligt tills du installerat dem.
+- Kör du utanför Docker behöver eSpeak NG finnas i systemet: `sudo apt-get install espeak-ng` (drar automatiskt in `libespeak-ng1`).
 
 ## GitHub-repo
 

--- a/app/main.py
+++ b/app/main.py
@@ -621,4 +621,12 @@ async def tts(payload: dict):
     except HTTPException:
         raise
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=f"TTS misslyckades: {exc}") from exc
+        message = str(exc)
+        if isinstance(exc, OSError) and "libespeak" in message.lower():
+            hint = (
+                "TTS kräver eSpeak NG-biblioteket. Installera paketet `espeak-ng` "
+                "(som innehåller libespeak-ng1) och försök igen."
+            )
+            raise HTTPException(status_code=500, detail=hint) from exc
+
+        raise HTTPException(status_code=500, detail=f"TTS misslyckades: {message}") from exc

--- a/scripts/install_pi.sh
+++ b/scripts/install_pi.sh
@@ -5,8 +5,10 @@ set -euo pipefail
 # - Installerar Ollama
 # - Skapar Python-venv och startar appen
 
-if ! command -v curl >/dev/null 2>&1; then
-  sudo apt-get update && sudo apt-get install -y curl ffmpeg
+# Säkerställ att nödvändiga systempaket finns (curl, ffmpeg, eSpeak NG)
+if command -v apt-get >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y curl ffmpeg espeak-ng
 fi
 
 # Installera Ollama om den saknas


### PR DESCRIPTION
## Summary
- ensure the Raspberry Pi installer installs eSpeak NG alongside curl and ffmpeg
- document the eSpeak NG requirement for bare-metal TTS usage
- surface a clearer FastAPI error when libespeak is missing so users know how to fix it

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cab530ffbc8320bd7c95acd2d31847